### PR TITLE
[Enhancement] Include video's real "added to playlist date" timestamp

### DIFF
--- a/freetube_import/freetube_import.py
+++ b/freetube_import/freetube_import.py
@@ -216,6 +216,7 @@ def process_playlist(playlist_filepath, log_errors=False, list_broken_videos=Fal
     write_counter = 0
     failed_yt_search = []
     failed_ID = []
+    latest_added_timestamp_ms = 0
     for video in tqdm(Videos, disable=logging.getLogger(__name__).isEnabledFor(logging.DEBUG)):
         video_UUID = uuid.uuid4()
         current_time_ms = int(time.time()*1000)
@@ -262,11 +263,14 @@ def process_playlist(playlist_filepath, log_errors=False, list_broken_videos=Fal
 
         if video.date_added_ms:
             video_dict["timeAdded"] = video.date_added_ms
+            latest_added_timestamp_ms = max(latest_added_timestamp_ms, video.date_added_ms)
 
         playlist_dict["videos"].append(video_dict)
         write_counter += 1
         logger.info(f"https://www.youtube.com/watch?v={video.id} written successfully")
     
+    playlist_dict["lastUpdatedAt"] = latest_added_timestamp_ms
+
     if len(playlist_dict["videos"]) != 0 and not stdin:
         outputfile = open(playlistname+".db", "w")
         outputfile.write(json.dumps(playlist_dict, separators = (',', ':'))+"\n")


### PR DESCRIPTION
## changes
As the title suggests, this PR embeds a playlist's video "added to playlist date" timestamp to the FreeTube exported playlist.

This used to be arbitrarily set to the current time:
https://github.com/NoSpiner/Freetube-import/blob/b5685c6edb2dc722e7f65850d1681bcdd08cf6d0/freetube_import/freetube_import.py#L210-L220

It also sets the playlist's `lastUpdatedAt` to the timestamp of the latest added video. Unfortunately, when importing the playlist into FreeTube, `lastUpdatedAt` ends up getting set to the current time anyway ¯\\_(ツ)_/¯

## motivation
I think this is really important. So much so, that immediately after testing the script and seeing that it wasn't doing so, I just went and implemented it myself :)
